### PR TITLE
Update viewport resolution settings

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -78,6 +78,7 @@ export class Cline {
 	didFinishAborting = false
 	abandoned = false
 	private diffViewProvider: DiffViewProvider
+	viewportResolution?: string
 
 	// streaming
 	private currentStreamingContentIndex = 0
@@ -98,6 +99,7 @@ export class Cline {
 		task?: string,
 		images?: string[],
 		historyItem?: HistoryItem,
+		viewportResolution?: string,
 	) {
 		this.providerRef = new WeakRef(provider)
 		this.api = buildApiHandler(apiConfiguration)
@@ -107,6 +109,7 @@ export class Cline {
 		this.diffViewProvider = new DiffViewProvider(cwd)
 		this.customInstructions = customInstructions
 		this.alwaysAllowReadOnly = alwaysAllowReadOnly ?? false
+		this.viewportResolution = viewportResolution
 
 		if (historyItem) {
 			this.taskId = historyItem.id
@@ -2350,6 +2353,10 @@ export class Cline {
 				const result = formatResponse.formatFilesList(cwd, files, didHitLimit)
 				details += result
 			}
+		}
+
+		if (this.viewportResolution) {
+			details += `\n\n# Viewport Resolution\n${this.viewportResolution}`
 		}
 
 		return `<environment_details>\n${details.trim()}\n</environment_details>`

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -833,7 +833,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 	}
 
 	async getStateToPostToWebview() {
-		const { apiConfiguration, lastShownAnnouncementId, customInstructions, alwaysAllowReadOnly, taskHistory } =
+		const { apiConfiguration, lastShownAnnouncementId, customInstructions, alwaysAllowReadOnly, taskHistory, viewportResolution } =
 			await this.getState()
 		return {
 			version: this.context.extension?.packageJSON?.version ?? "",
@@ -844,6 +844,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			clineMessages: this.cline?.clineMessages || [],
 			taskHistory: (taskHistory || []).filter((item) => item.ts && item.task).sort((a, b) => b.ts - a.ts),
 			shouldShowAnnouncement: lastShownAnnouncementId !== this.latestAnnouncementId,
+			viewportResolution,
 		}
 	}
 

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -53,6 +53,9 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage }: 
 
 	const handleInputChange = (field: keyof ApiConfiguration) => (event: any) => {
 		setApiConfiguration({ ...apiConfiguration, [field]: event.target.value })
+		if (field === "viewportResolution") {
+			vscode.postMessage({ type: "viewportResolution", resolution: event.target.value })
+		}
 	}
 
 	const { selectedProvider, selectedModelId, selectedModelInfo } = useMemo(() => {
@@ -83,6 +86,10 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage }: 
 		}
 	}, [])
 	useEvent("message", handleMessage)
+
+	useEffect(() => {
+		setViewportResolution(apiConfiguration?.viewportResolution || "1280x720")
+	}, [apiConfiguration?.viewportResolution])
 
 	/*
 	VSCodeDropdown has an open bug where dynamically rendered options don't auto select the provided value prop. You can see this for yourself by comparing  it with normal select/option elements, which work as expected.
@@ -651,36 +658,36 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage }: 
 					}}>
 					{modelIdErrorMessage}
 				</p>
-				)}
+			)}
 
-				<div style={{ marginBottom: 5 }}>
-					<label htmlFor="viewport-resolution">
-						<span style={{ fontWeight: 500 }}>Viewport Resolution</span>
-					</label>
-					<VSCodeDropdown
-						id="viewport-resolution"
-						value={viewportResolution}
-						onChange={(e: any) => setViewportResolution(e.target.value)}
-						style={{ width: "100%" }}>
-						<VSCodeOption value="1280x720">1280x720 (HD)</VSCodeOption>
-						<VSCodeOption value="1920x1080">1920x1080 (Full HD)</VSCodeOption>
-						<VSCodeOption value="1366x768">1366x768 (WXGA)</VSCodeOption>
-						<VSCodeOption value="1440x900">1440x900 (WXGA+)</VSCodeOption>
-						<VSCodeOption value="1536x864">1536x864 (HD+)</VSCodeOption>
-						<VSCodeOption value="1600x900">1600x900 (HD+)</VSCodeOption>
-						<VSCodeOption value="1680x1050">1680x1050 (WSXGA+)</VSCodeOption>
-						<VSCodeOption value="2560x1440">2560x1440 (QHD)</VSCodeOption>
-						<VSCodeOption value="3840x2160">3840x2160 (4K UHD)</VSCodeOption>
-					</VSCodeDropdown>
-					<p
-						style={{
-							fontSize: "12px",
-							marginTop: "5px",
-							color: "var(--vscode-descriptionForeground)",
-						}}>
-						Select a common resolution for the viewport while the extension is running.
-					</p>
-				</div>
+			<div style={{ marginBottom: 5 }}>
+				<label htmlFor="viewport-resolution">
+					<span style={{ fontWeight: 500 }}>Viewport Resolution</span>
+				</label>
+				<VSCodeDropdown
+					id="viewport-resolution"
+					value={viewportResolution}
+					onChange={handleInputChange("viewportResolution")}
+					style={{ width: "100%" }}>
+					<VSCodeOption value="1280x720">1280x720 (HD)</VSCodeOption>
+					<VSCodeOption value="1920x1080">1920x1080 (Full HD)</VSCodeOption>
+					<VSCodeOption value="1366x768">1366x768 (WXGA)</VSCodeOption>
+					<VSCodeOption value="1440x900">1440x900 (WXGA+)</VSCodeOption>
+					<VSCodeOption value="1536x864">1536x864 (HD+)</VSCodeOption>
+					<VSCodeOption value="1600x900">1600x900 (HD+)</VSCodeOption>
+					<VSCodeOption value="1680x1050">1680x1050 (WSXGA+)</VSCodeOption>
+					<VSCodeOption value="2560x1440">2560x1440 (QHD)</VSCodeOption>
+					<VSCodeOption value="3840x2160">3840x2160 (4K UHD)</VSCodeOption>
+				</VSCodeDropdown>
+				<p
+					style={{
+						fontSize: "12px",
+						marginTop: "5px",
+						color: "var(--vscode-descriptionForeground)",
+					}}>
+					Select a common resolution for the viewport while the extension is running.
+				</p>
+			</div>
 		</div>
 	)
 }


### PR DESCRIPTION
Add viewport resolution support to the Cline class and update related components.

* **Cline.ts**
  - Add `viewportResolution` property to the `Cline` class.
  - Update the constructor to accept `viewportResolution` as a parameter and set the new property.
  - Update the `loadContext` method to include the viewport resolution in the environment details.

* **ClineProvider.ts**
  - Update the `getStateToPostToWebview` method to include `viewportResolution` in the returned state.

* **ApiOptions.tsx**
  - Add a new dropdown for selecting the viewport resolution.
  - Update the `handleInputChange` function to handle changes to the viewport resolution.
  - Update the `useEffect` hook to set the initial value of the viewport resolution from the state.

